### PR TITLE
Remove constexpr for absl::string_view since it reports C2131

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include_directories(
  )
 
 target_link_libraries(ros_type_introspection ${catkin_LIBRARIES})
-
+set_target_properties(ros_type_introspection PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 #############
 ## Install ##

--- a/include/ros_type_introspection/stringtree_leaf.hpp
+++ b/include/ros_type_introspection/stringtree_leaf.hpp
@@ -99,7 +99,7 @@ struct StringTreeLeaf{
   constexpr static const char NUM_PLACEHOLDER = '#';
 
   static const absl::string_view& num_placeholder() {
-    constexpr static const absl::string_view nph("#");
+    static const absl::string_view nph("#");
     return nph;
   }
 };


### PR DESCRIPTION
The implementation of absl::string_view for MSVC is not constexpr (on GCC there is a different code path), so the C2131 will be reported here. For now I removed this modifier to avoid the Windows build break. Ideally it should be fixed on the upstream (like abseil project?)